### PR TITLE
Exclude tests from packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/resgroup/mini-wake",
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages(exclude=['tests.*', 'tests']),
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Without this, `setuptools.find_packages()` returns `['miniwake', 'tests']`